### PR TITLE
Minimal support for PVR Addon API 1.9.7

### DIFF
--- a/pvr.dvbviewer/addon.xml
+++ b/pvr.dvbviewer/addon.xml
@@ -6,7 +6,7 @@
   provider-name="A600, Manuel Mausz">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.6"/>
+    <import addon="xbmc.pvr" version="1.9.7"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.dvbviewer/addon.xml
+++ b/pvr.dvbviewer/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvbviewer"
-  version="1.10.33"
+  version="1.11.0"
   name="DVBViewer Client"
   provider-name="A600, Manuel Mausz">
   <requires>

--- a/pvr.dvbviewer/changelog.txt
+++ b/pvr.dvbviewer/changelog.txt
@@ -1,5 +1,7 @@
-1.10.33
+1.11.0
+[updated] to PVR API v1.9.7
 
+1.10.33
 [updated] Language files from Transifex
 
 1.10.32

--- a/src/DvbData.cpp
+++ b/src/DvbData.cpp
@@ -291,6 +291,10 @@ bool Dvb::GetTimers(ADDON_HANDLE handle)
   {
     PVR_TIMER tag;
     memset(&tag, 0, sizeof(PVR_TIMER));
+
+    /* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
+    tag.iTimerType = PVR_TIMER_TYPE_NONE;
+
     PVR_STRCPY(tag.strTitle,   timer->title.c_str());
     tag.iClientIndex      = timer->id;
     tag.iClientChannelUid = timer->channel->id;
@@ -298,7 +302,6 @@ bool Dvb::GetTimers(ADDON_HANDLE handle)
     tag.endTime           = timer->end;
     tag.state             = timer->state;
     tag.iPriority         = timer->priority;
-    tag.bIsRepeating      = (timer->weekdays != 0);
     tag.firstDay          = (timer->weekdays != 0) ? timer->start : 0;
     tag.iWeekdays         = timer->weekdays;
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -446,6 +446,13 @@ PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &g
 }
 
 /* timer functions */
+
+PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
+{
+  /* TODO: Implement this to get support for the timer features introduced with PVR API 1.9.7 */
+  return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
 int GetTimersAmount(void)
 {
   if (!DvbData || !DvbData->IsConnected())
@@ -456,6 +463,7 @@ int GetTimersAmount(void)
 
 PVR_ERROR GetTimers(ADDON_HANDLE handle)
 {
+  /* TODO: Change implementation to get support for the timer features introduced with PVR API 1.9.7 */
   return (DvbData && DvbData->IsConnected() && DvbData->GetTimers(handle))
     ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
 }
@@ -472,8 +480,9 @@ PVR_ERROR UpdateTimer(const PVR_TIMER &timer)
     ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool _UNUSED(bForceDelete))
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool _UNUSED(bForceDelete), bool _UNUSED(bDeleteScheduled))
 {
+  /* TODO: Change implementation to support bDeleteScheduled (introduced with PVR API 1.9.7 */
   return (DvbData && DvbData->IsConnected() && DvbData->DeleteTimer(timer))
     ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
 }


### PR DESCRIPTION
For, J**** PVR Addon API will be bumped to version 1.9.7 to introduce a couple of new features and enhancements for timers (esp. official series recording support). => https://github.com/xbmc/xbmc/pull/7079

This PR will ensure compatibility with and add minimalistic support for PVR addon API 1.9.7. Even if the maintainers of this addon will do nothing except merging this PR and bump the addon version in Kodi, the addon will still be usable in J**** and not loose any functionality compared to Isengard, but it will not profit from the new features. For the latter, every addon maintainer must do the respective changes on his own.