### PR TITLE
Update to PVR addon API v4.0.0

### DIFF
--- a/pvr.dvbviewer/addon.xml.in
+++ b/pvr.dvbviewer/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvbviewer"
-  version="1.11.5"
+  version="1.11.6"
   name="DVBViewer Client"
   provider-name="A600, Manuel Mausz">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="3.0.0"/>
+    <import addon="xbmc.pvr" version="4.0.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.dvbviewer/changelog.txt
+++ b/pvr.dvbviewer/changelog.txt
@@ -1,3 +1,6 @@
+1.11.6 (09-09-2015)
+[updated] to PVR API v4.0.0
+
 1.11.5 (14-08-2015)
 [updated] to PVR API v3.0.0 (API 1.9.7 compatibility mode)
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -480,9 +480,8 @@ PVR_ERROR UpdateTimer(const PVR_TIMER &timer)
     ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool _UNUSED(bForceDelete), bool _UNUSED(bDeleteScheduled))
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool _UNUSED(bForceDelete))
 {
-  /* TODO: Change implementation to support bDeleteScheduled (introduced with PVR API 1.9.7 */
   return (DvbData && DvbData->IsConnected() && DvbData->DeleteTimer(timer))
     ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
 }


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.0.0, including a PVR addon micro version bump.

Details can be found here: https://github.com/xbmc/xbmc/pull/8005