### PR TITLE
Update to PVR addon API v4.1.0

### DIFF
--- a/pvr.dvbviewer/addon.xml.in
+++ b/pvr.dvbviewer/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvbviewer"
-  version="1.11.6"
+  version="1.11.7"
   name="DVBViewer Client"
   provider-name="A600, Manuel Mausz">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.0.0"/>
+    <import addon="xbmc.pvr" version="4.1.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.dvbviewer/changelog.txt
+++ b/pvr.dvbviewer/changelog.txt
@@ -1,13 +1,16 @@
-1.11.6 (09-09-2015)
+1.11.7
+[updated] to PVR API v4.1.0
+
+1.11.6
 [updated] to PVR API v4.0.0
 
-1.11.5 (14-08-2015)
+1.11.5
 [updated] to PVR API v3.0.0 (API 1.9.7 compatibility mode)
 
-1.11.4 (05-08-2015)
+1.11.4
 [updated] Automatically fill in platform and library name
 
-1.11.3 (19-07-2015)
+1.11.3
 [updated] to PVR API v2.1.0
 
 1.11.2

--- a/src/DvbData.cpp
+++ b/src/DvbData.cpp
@@ -210,6 +210,7 @@ bool Dvb::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL& channelinfo,
     broadcast.strPlot             = entry.plot.c_str();
     broadcast.iGenreType          = entry.genre & 0xF0;
     broadcast.iGenreSubType       = entry.genre & 0x0F;
+    broadcast.iFlags              = EPG_TAG_FLAG_UNDEFINED;
 
     PVR->TransferEpgEntry(handle, &broadcast);
     ++numEPG;


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.1.0, including a PVR addon micro version bump.

Details can be found here: xbmc/xbmc#8075