### PR TITLE
Implement PVR API 5.1.0 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,44 @@ set(DEPLIBS ${kodiplatform_LIBRARIES}
             ${p8-platform_LIBRARIES}
             ${TINYXML_LIBRARIES})
 
+# check if the linker supports version script or symbols list
+if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+  include(CheckCXXCompilerFlag)
+  file(READ "${PROJECT_SOURCE_DIR}/symbols.exp" __symbols_exp)
+  string(STRIP ${__symbols_exp} __symbols_exp)
+  set(__symbols_file "${CMAKE_CURRENT_BINARY_DIR}/symbols.exp")
+  unset(__ldflags)
+
+  if(NOT __ldflags)
+    # gnu ld
+    file(WRITE ${__symbols_file} "{ local: *; };\n")
+    set(CMAKE_REQUIRED_FLAGS "-Wl,--version-script=${__symbols_file}")
+    check_cxx_compiler_flag("" LD_ACCEPTS_VERSION_SCRIPT)
+    if(LD_ACCEPTS_VERSION_SCRIPT)
+      string(REPLACE "\n" "; " __symbols ${__symbols_exp})
+      file(WRITE ${__symbols_file} "{ global: ${__symbols}; local: *; };\n")
+      set(__ldflags "-Wl,--version-script=${__symbols_file}")
+    endif()
+  endif()
+
+  if(NOT __ldflags)
+    # darwin ld
+    file(WRITE ${__symbols_file} "\n")
+    set(CMAKE_REQUIRED_FLAGS "-Wl,-exported_symbols_list,${__symbols_file}")
+    check_cxx_compiler_flag("" LD_ACCEPTS_SYMBOLS_LIST)
+    if(LD_ACCEPTS_SYMBOLS_LIST)
+      string(REPLACE "\n" "\n_" __symbols ${__symbols_exp})
+      file(WRITE ${__symbols_file} "_${__symbols}\n")
+      set(__ldflags "-Wl,-exported_symbols_list,${__symbols_file}")
+    endif()
+  endif()
+
+  if(__ldflags)
+    add_options(ALL_LANGUAGES ALL_BUILDS "${__ldflags}")
+  endif()
+  unset(CMAKE_REQUIRED_FLAGS)
+endif()
+
 build_addon(pvr.dvbviewer DVBVIEWER DEPLIBS)
 
 include(CPack)

--- a/pvr.dvbviewer/addon.xml.in
+++ b/pvr.dvbviewer/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvbviewer"
-  version="2.0.1"
+  version="2.1.0"
   name="DVBViewer Client"
   provider-name="A600, Manuel Mausz">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.1.0"/>
+    <import addon="xbmc.pvr" version="5.1.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.dvbviewer/changelog.txt
+++ b/pvr.dvbviewer/changelog.txt
@@ -1,3 +1,9 @@
+2.1.0
+[updated] to PVR API v5.1.0
+[updated] extend low performance mode
+[fixed] fixed channel switching with timeshift enabled
+[fixed] various thread saftey and code fixes
+
 2.0.1
 
 [updated] Language files from Transifex

--- a/src/DvbData.cpp
+++ b/src/DvbData.cpp
@@ -123,11 +123,6 @@ bool Dvb::GetChannels(ADDON_HANDLE handle, bool radio)
     PVR_STRCPY(xbmcChannel.strChannelName, channel->name.c_str());
     PVR_STRCPY(xbmcChannel.strIconPath,    channel->logoURL.c_str());
 
-    if (!channel->radio && !g_useRTSP)
-      PVR_STRCPY(xbmcChannel.strInputFormat, "video/mp2t");
-    else
-      PVR_STRCPY(xbmcChannel.strInputFormat, "");
-
     if (!g_useTimeshift)
     {
       // self referencing so GetLiveStreamURL() gets triggered

--- a/src/DvbData.cpp
+++ b/src/DvbData.cpp
@@ -93,7 +93,8 @@ bool Dvb::SwitchChannel(const PVR_CHANNEL &channelinfo)
 {
   CLockObject lock(m_mutex);
   m_currentChannel = channelinfo.iUniqueId;
-  m_updateEPG = true;
+  if (!g_lowPerformance)
+    m_updateEPG = true;
   return true;
 }
 
@@ -581,6 +582,7 @@ void *Dvb::Process()
 {
   XBMC->Log(LOG_DEBUG, "%s: Running...", __FUNCTION__);
   int update = 0;
+  int interval = (!g_lowPerformance) ? 60 : 300;
 
   while (!IsStopped())
   {
@@ -609,7 +611,7 @@ void *Dvb::Process()
       update = 0;
     }
 
-    if (update >= 60)
+    if (update >= interval)
     {
       update = 0;
       XBMC->Log(LOG_INFO, "Performing timer/recording updates!");

--- a/src/DvbData.cpp
+++ b/src/DvbData.cpp
@@ -290,17 +290,15 @@ bool Dvb::GetTimers(ADDON_HANDLE handle)
     PVR_TIMER tag;
     memset(&tag, 0, sizeof(PVR_TIMER));
 
-    /* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
-    tag.iTimerType = PVR_TIMER_TYPE_NONE;
-
     PVR_STRCPY(tag.strTitle, timer.title.c_str());
     tag.iClientIndex      = timer.id;
     tag.iClientChannelUid = timer.channel->id;
     tag.startTime         = timer.start;
     tag.endTime           = timer.end;
     tag.state             = timer.state;
+    /* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
+    tag.iTimerType        = PVR_TIMER_TYPE_NONE;
     tag.iPriority         = timer.priority;
-    tag.bIsRepeating      = (timer.weekdays != 0);
     tag.firstDay          = (timer.weekdays != 0) ? timer.start : 0;
     tag.iWeekdays         = timer.weekdays;
 
@@ -465,6 +463,8 @@ bool Dvb::GetRecordings(ADDON_HANDLE handle)
     recinfo.iDuration     = recording.duration;
     recinfo.iGenreType    = recording.genre & 0xF0;
     recinfo.iGenreSubType = recording.genre & 0x0F;
+    recinfo.iChannelUid   = PVR_CHANNEL_INVALID_UID; // TODO: try searching by name
+    recinfo.channelType   = PVR_RECORDING_CHANNEL_TYPE_TV;
 
     CStdString tmp;
     switch(g_groupRecordings)

--- a/src/DvbData.h
+++ b/src/DvbData.h
@@ -197,31 +197,31 @@ public:
   CStdString GetBackendVersion();
   bool GetDriveSpace(long long *total, long long *used);
 
-  bool SwitchChannel(const PVR_CHANNEL& channelinfo);
+  bool SwitchChannel(const PVR_CHANNEL &channelinfo);
   unsigned int GetCurrentClientChannel(void);
   bool GetChannels(ADDON_HANDLE handle, bool radio);
-  bool GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL& channelinfo,
+  bool GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channelinfo,
       time_t start, time_t end);
   unsigned int GetChannelsAmount(void);
 
   bool GetChannelGroups(ADDON_HANDLE handle, bool radio);
   bool GetChannelGroupMembers(ADDON_HANDLE handle,
-      const PVR_CHANNEL_GROUP& group);
+      const PVR_CHANNEL_GROUP &group);
   unsigned int GetChannelGroupsAmount(void);
 
   bool GetTimers(ADDON_HANDLE handle);
-  bool AddTimer(const PVR_TIMER& timer, bool update = false);
-  bool DeleteTimer(const PVR_TIMER& timer);
+  bool AddTimer(const PVR_TIMER &timer, bool update = false);
+  bool DeleteTimer(const PVR_TIMER &timer);
   unsigned int GetTimersAmount(void);
 
   bool GetRecordings(ADDON_HANDLE handle);
-  bool DeleteRecording(const PVR_RECORDING& recinfo);
+  bool DeleteRecording(const PVR_RECORDING &recinfo);
   unsigned int GetRecordingsAmount();
   RecordingReader *OpenRecordedStream(const PVR_RECORDING &recinfo);
 
-  bool OpenLiveStream(const PVR_CHANNEL& channelinfo);
+  bool OpenLiveStream(const PVR_CHANNEL &channelinfo);
   void CloseLiveStream();
-  const CStdString& GetLiveStreamURL(const PVR_CHANNEL& channelinfo);
+  const CStdString &GetLiveStreamURL(const PVR_CHANNEL &channelinfo);
 
 protected:
   virtual void *Process(void);

--- a/src/DvbData.h
+++ b/src/DvbData.h
@@ -3,8 +3,8 @@
 #ifndef PVR_DVBVIEWER_DVBDATA_H
 #define PVR_DVBVIEWER_DVBDATA_H
 
-#include "client.h"
 #include "RecordingReader.h"
+#include "kodi/libXBMC_pvr.h"
 #include "p8-platform/util/StdString.h"
 #include "p8-platform/threads/threads.h"
 #include <list>
@@ -40,7 +40,7 @@ public:
   {}
 
 public:
-  /*!< @brief unique id passed to xbmc database.
+  /*!< @brief unique id passed to kodi's database.
    * starts at 1 and increases by each channel regardless of hidden state.
    * see FIXME for more details
    */
@@ -94,16 +94,17 @@ public:
 class DvbTimer
 {
 public:
-  enum State
+  enum class State
+    : uint8_t
   {
-    STATE_NONE,
-    STATE_NEW,
-    STATE_FOUND,
-    STATE_UPDATED
+    NONE,
+    NEW,
+    FOUND,
+    UPDATED
   };
 
   DvbTimer()
-    : updateState(STATE_NEW)
+    : updateState(State::NEW)
   {}
 
 #define TIMER_UPDATE_MEMBER(member) \
@@ -127,7 +128,7 @@ public:
   }
 
 public:
-  /*!< @brief unique id passed to xbmc database
+  /*!< @brief unique id passed to kodi's database
    * starts at 1 and increases by each new timer. never decreases.
    */
   unsigned int id;
@@ -150,14 +151,15 @@ public:
 class DvbRecording
 {
 public:
-  enum Grouping
+  enum class Grouping
+    : int // same type as addon settings
   {
-    GROUPING_DISABLED = 0,
-    GROUP_BY_DIRECTORY,
-    GROUP_BY_DATE,
-    GROUP_BY_FIRST_LETTER,
-    GROUP_BY_TV_CHANNEL,
-    GROUP_BY_SERIES
+    DISABLED = 0,
+    BY_DIRECTORY,
+    BY_DATE,
+    BY_FIRST_LETTER,
+    BY_TV_CHANNEL,
+    BY_SERIES
   };
 
 public:
@@ -219,7 +221,7 @@ public:
 
   bool OpenLiveStream(const PVR_CHANNEL& channelinfo);
   void CloseLiveStream();
-  CStdString& GetLiveStreamURL(const PVR_CHANNEL& channelinfo);
+  const CStdString& GetLiveStreamURL(const PVR_CHANNEL& channelinfo);
 
 protected:
   virtual void *Process(void);

--- a/src/RecordingReader.cpp
+++ b/src/RecordingReader.cpp
@@ -8,7 +8,7 @@
 
 using namespace ADDON;
 
-RecordingReader::RecordingReader(CStdString streamURL, time_t end)
+RecordingReader::RecordingReader(const CStdString &streamURL, time_t end)
   : m_streamURL(streamURL), m_end(end), m_fastReopen(false), m_playback(false)
 {
   m_readHandle = XBMC->OpenFile(m_streamURL, 0);

--- a/src/RecordingReader.cpp
+++ b/src/RecordingReader.cpp
@@ -28,10 +28,10 @@ RecordingReader::~RecordingReader(void)
 
 bool RecordingReader::IsValid()
 {
-  return (m_readHandle != NULL);
+  return (m_readHandle != nullptr);
 }
 
-int RecordingReader::ReadData(unsigned char *buffer, unsigned int size)
+ssize_t RecordingReader::ReadData(unsigned char *buffer, unsigned int size)
 {
   /* check for playback of ongoing recording */
   if (m_playback && m_end)
@@ -68,12 +68,12 @@ FORCE_REOPEN:
     }
   }
 
-  unsigned int read = XBMC->ReadFile(m_readHandle, buffer, size);
+  ssize_t read = XBMC->ReadFile(m_readHandle, buffer, size);
   m_pos += read;
   return read;
 }
 
-long long RecordingReader::Seek(long long position, int whence)
+int64_t RecordingReader::Seek(long long position, int whence)
 {
   int64_t ret = XBMC->SeekFile(m_readHandle, position, whence);
   // for unknown reason seek sometimes doesn't return the correct position
@@ -83,12 +83,12 @@ long long RecordingReader::Seek(long long position, int whence)
   return ret;
 }
 
-long long RecordingReader::Position()
+int64_t RecordingReader::Position()
 {
   return m_pos;
 }
 
-long long RecordingReader::Length()
+int64_t RecordingReader::Length()
 {
   return m_len;
 }

--- a/src/RecordingReader.h
+++ b/src/RecordingReader.h
@@ -10,11 +10,11 @@ class RecordingReader
 public:
   RecordingReader(const CStdString &streamURL, time_t end);
   ~RecordingReader(void);
-  int ReadData(unsigned char *buffer, unsigned int size);
+  ssize_t ReadData(unsigned char *buffer, unsigned int size);
   bool IsValid();
-  long long Seek(long long position, int whence);
-  long long Position();
-  long long Length();
+  int64_t Seek(long long position, int whence);
+  int64_t Position();
+  int64_t Length();
   void Announce(const char *message);
 
 private:

--- a/src/RecordingReader.h
+++ b/src/RecordingReader.h
@@ -8,7 +8,7 @@
 class RecordingReader
 {
 public:
-  RecordingReader(CStdString streamURL, time_t end);
+  RecordingReader(const CStdString &streamURL, time_t end);
   ~RecordingReader(void);
   int ReadData(unsigned char *buffer, unsigned int size);
   bool IsValid();

--- a/src/TimeshiftBuffer.cpp
+++ b/src/TimeshiftBuffer.cpp
@@ -38,9 +38,9 @@ TimeshiftBuffer::~TimeshiftBuffer(void)
 
 bool TimeshiftBuffer::IsValid()
 {
-  return (m_streamHandle != NULL
-      && m_filebufferWriteHandle != NULL
-      && m_filebufferReadHandle != NULL);
+  return (m_streamHandle != nullptr
+      && m_filebufferWriteHandle != nullptr
+      && m_filebufferReadHandle != nullptr);
 }
 
 void *TimeshiftBuffer::Process()
@@ -63,20 +63,20 @@ void *TimeshiftBuffer::Process()
   return NULL;
 }
 
-long long TimeshiftBuffer::Seek(long long position, int whence)
+int64_t TimeshiftBuffer::Seek(long long position, int whence)
 {
   return XBMC->SeekFile(m_filebufferReadHandle, position, whence);
 }
 
-long long TimeshiftBuffer::Position()
+int64_t TimeshiftBuffer::Position()
 {
   return XBMC->GetFilePosition(m_filebufferReadHandle);
 }
 
-long long TimeshiftBuffer::Length()
+int64_t TimeshiftBuffer::Length()
 {
   // We can't use GetFileLength here as it's value will be cached
-  // by XBMC until we read or seek above it.
+  // by Kodi until we read or seek above it.
   // see xbm/xbmc/filesystem/HDFile.cpp CHDFile::GetLength()
   //return XBMC->GetFileLength(m_filebufferReadHandle);
 
@@ -93,7 +93,7 @@ long long TimeshiftBuffer::Length()
   return writePos;
 }
 
-int TimeshiftBuffer::ReadData(unsigned char *buffer, unsigned int size)
+ssize_t TimeshiftBuffer::ReadData(unsigned char *buffer, unsigned int size)
 {
   /* make sure we never read above the current write position */
   int64_t readPos = XBMC->GetFilePosition(m_filebufferReadHandle);
@@ -120,4 +120,11 @@ time_t TimeshiftBuffer::TimeStart()
 time_t TimeshiftBuffer::TimeEnd()
 {
   return time(NULL);
+}
+
+bool TimeshiftBuffer::NearEnd()
+{
+  // other PVRs use 10 seconds here, but we aren't doing any demuxing
+  // we'll therefore just asume 1 secs needs about 1mb
+  return Length() - Position() <= 10 * 1048576;
 }

--- a/src/TimeshiftBuffer.cpp
+++ b/src/TimeshiftBuffer.cpp
@@ -26,9 +26,7 @@ TimeshiftBuffer::TimeshiftBuffer(const CStdString &streamURL,
 
 TimeshiftBuffer::~TimeshiftBuffer(void)
 {
-  Stop();
-  if (IsRunning())
-    StopThread();
+  StopThread(0);
 
   if (m_filebufferWriteHandle)
     XBMC->CloseFile(m_filebufferWriteHandle);
@@ -45,17 +43,12 @@ bool TimeshiftBuffer::IsValid()
       && m_filebufferReadHandle != NULL);
 }
 
-void TimeshiftBuffer::Stop()
-{
-  m_start = 0;
-}
-
 void *TimeshiftBuffer::Process()
 {
   XBMC->Log(LOG_DEBUG, "Timeshift: Thread started");
   byte buffer[STREAM_READ_BUFFER_SIZE];
 
-  while (m_start)
+  while (!IsStopped())
   {
     unsigned int read = XBMC->ReadFile(m_streamHandle, buffer, sizeof(buffer));
     XBMC->WriteFile(m_filebufferWriteHandle, buffer, read);
@@ -126,5 +119,5 @@ time_t TimeshiftBuffer::TimeStart()
 
 time_t TimeshiftBuffer::TimeEnd()
 {
-  return (m_start) ? time(NULL) : 0;
+  return time(NULL);
 }

--- a/src/TimeshiftBuffer.cpp
+++ b/src/TimeshiftBuffer.cpp
@@ -8,7 +8,8 @@
 
 using namespace ADDON;
 
-TimeshiftBuffer::TimeshiftBuffer(CStdString streamURL, CStdString bufferPath)
+TimeshiftBuffer::TimeshiftBuffer(const CStdString &streamURL,
+    const CStdString &bufferPath)
   : m_bufferPath(bufferPath)
 {
   m_streamHandle = XBMC->OpenFile(streamURL, READ_NO_CACHE);

--- a/src/TimeshiftBuffer.h
+++ b/src/TimeshiftBuffer.h
@@ -10,7 +10,7 @@ class TimeshiftBuffer
   : public P8PLATFORM::CThread
 {
 public:
-  TimeshiftBuffer(CStdString streamURL, CStdString bufferPath);
+  TimeshiftBuffer(const CStdString &streamURL, const CStdString &bufferPath);
   ~TimeshiftBuffer(void);
   bool IsValid();
   int ReadData(unsigned char *buffer, unsigned int size);

--- a/src/TimeshiftBuffer.h
+++ b/src/TimeshiftBuffer.h
@@ -17,7 +17,6 @@ public:
   long long Seek(long long position, int whence);
   long long Position();
   long long Length();
-  void Stop(void);
   time_t TimeStart();
   time_t TimeEnd();
 

--- a/src/TimeshiftBuffer.h
+++ b/src/TimeshiftBuffer.h
@@ -13,12 +13,13 @@ public:
   TimeshiftBuffer(const CStdString &streamURL, const CStdString &bufferPath);
   ~TimeshiftBuffer(void);
   bool IsValid();
-  int ReadData(unsigned char *buffer, unsigned int size);
-  long long Seek(long long position, int whence);
-  long long Position();
-  long long Length();
+  ssize_t ReadData(unsigned char *buffer, unsigned int size);
+  int64_t Seek(long long position, int whence);
+  int64_t Position();
+  int64_t Length();
   time_t TimeStart();
   time_t TimeEnd();
+  bool NearEnd();
 
 private:
   virtual void *Process(void);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -23,7 +23,6 @@
 #include "TimeshiftBuffer.h"
 #include "RecordingReader.h"
 #include "kodi/xbmc_pvr_dll.h"
-#include "kodi/libKODI_guilib.h"
 #include "p8-platform/util/util.h"
 #include <stdlib.h>
 
@@ -48,11 +47,11 @@ PrependOutline g_prependOutline       = PrependOutline::IN_EPG;
 bool           g_lowPerformance       = false;
 
 ADDON_STATUS m_curStatus    = ADDON_STATUS_UNKNOWN;
-CHelper_libXBMC_addon *XBMC = NULL;
-CHelper_libXBMC_pvr   *PVR  = NULL;
-Dvb *DvbData                = NULL;
-TimeshiftBuffer *tsBuffer   = NULL;
-RecordingReader *recReader  = NULL;
+CHelper_libXBMC_addon *XBMC = nullptr;
+CHelper_libXBMC_pvr   *PVR  = nullptr;
+Dvb *DvbData                = nullptr;
+TimeshiftBuffer *tsBuffer   = nullptr;
+RecordingReader *recReader  = nullptr;
 
 extern "C"
 {
@@ -289,7 +288,7 @@ void ADDON_FreeSettings()
 void ADDON_Announce(const char *_UNUSED(flag), const char *sender,
     const char *message, const void *_UNUSED(data))
 {
-  if (recReader != NULL && strcmp(sender, "xbmc") == 0)
+  if (recReader != nullptr && strcmp(sender, "xbmc") == 0)
     recReader->Announce(message);
 }
 
@@ -309,26 +308,26 @@ const char* GetMininumPVRAPIVersion(void)
 
 const char* GetGUIAPIVersion(void)
 {
-  return KODI_GUILIB_API_VERSION;
+  return ""; // GUI API not used
 }
 
 const char* GetMininumGUIAPIVersion(void)
 {
-  return KODI_GUILIB_MIN_API_VERSION;
+  return ""; // GUI API not used
 }
 
 PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
 {
-  pCapabilities->bSupportsEPG             = true;
-  pCapabilities->bSupportsTV              = true;
-  pCapabilities->bSupportsRadio           = true;
-  pCapabilities->bSupportsRecordings      = true;
+  pCapabilities->bSupportsEPG                = true;
+  pCapabilities->bSupportsTV                 = true;
+  pCapabilities->bSupportsRadio              = true;
+  pCapabilities->bSupportsRecordings         = true;
   pCapabilities->bSupportsRecordingsUndelete = false;
-  pCapabilities->bSupportsTimers          = true;
-  pCapabilities->bSupportsChannelGroups   = true;
-  pCapabilities->bSupportsChannelScan     = false;
-  pCapabilities->bHandlesInputStream      = false;
-  pCapabilities->bHandlesDemuxing         = false;
+  pCapabilities->bSupportsTimers             = true;
+  pCapabilities->bSupportsChannelGroups      = true;
+  pCapabilities->bSupportsChannelScan        = false;
+  pCapabilities->bHandlesInputStream         = true;
+  pCapabilities->bHandlesDemuxing            = false;
   pCapabilities->bSupportsLastPlayedPosition = false;
 
   return PVR_ERROR_NO_ERROR;
@@ -404,20 +403,17 @@ int GetChannelsAmount(void)
   return DvbData->GetChannelsAmount();
 }
 
-int GetCurrentClientChannel(void)
-{
-  if (!DvbData || !DvbData->IsConnected())
-    return PVR_ERROR_SERVER_ERROR;
-
-  return DvbData->GetCurrentClientChannel();
-}
-
 bool SwitchChannel(const PVR_CHANNEL &channel)
 {
   if (!DvbData || !DvbData->IsConnected())
     return false;
 
-  return DvbData->SwitchChannel(channel);
+  if (channel.iUniqueId == DvbData->GetCurrentClientChannel())
+    return true;
+
+  /* as of late we need to close and reopen ourself */
+  CloseLiveStream();
+  return OpenLiveStream(channel);
 }
 
 /* channel group functions */
@@ -491,9 +487,6 @@ bool OpenLiveStream(const PVR_CHANNEL &channel)
   if (!DvbData || !DvbData->IsConnected())
     return false;
 
-  if (channel.iUniqueId == DvbData->GetCurrentClientChannel())
-    return true;
-
   if (!DvbData->OpenLiveStream(channel))
     return false;
   if (!g_useTimeshift)
@@ -521,6 +514,16 @@ const char *GetLiveStreamURL(const PVR_CHANNEL &channel)
 
   DvbData->SwitchChannel(channel);
   return DvbData->GetLiveStreamURL(channel).c_str();
+}
+
+bool IsRealTimeStream()
+{
+  if (!tsBuffer)
+    return true;
+  //FIXME as soon as we return false here the players current time value starts
+  // flickering/jumping
+  //return tsBuffer->NearEnd();
+  return true;
 }
 
 bool CanPauseStream(void)
@@ -569,6 +572,11 @@ long long LengthLiveStream(void)
     return -1;
 
   return tsBuffer->Length();
+}
+
+bool IsTimeshifting(void)
+{
+  return (tsBuffer != nullptr);
 }
 
 time_t GetBufferTimeStart()
@@ -682,9 +690,9 @@ PVR_ERROR RenameRecording(const PVR_RECORDING &_UNUSED(recording)) { return PVR_
 PVR_ERROR GetRecordingEdl(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*) { return PVR_ERROR_NOT_IMPLEMENTED; };
 PVR_ERROR UndeleteRecording(const PVR_RECORDING& _UNUSED(recording)) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteAllRecordingsFromTrash() { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR SetEPGTimeFrame(int iDays) { return PVR_ERROR_NOT_IMPLEMENTED; }
 unsigned int GetChannelSwitchDelay(void) { return 0; }
 void PauseStream(bool _UNUSED(bPaused)) {}
-bool SeekTime(int, bool, double*) { return false; }
-void SetSpeed(int) {};
-bool IsTimeshifting(void) { return false; }
+bool SeekTime(int time, bool backwards, double *startpts) { return false; }
+void SetSpeed(int speed) {};
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -33,19 +33,19 @@ using namespace ADDON;
  * Default values are defined inside client.h
  * and exported to the other source files.
  */
-CStdString g_hostname             = DEFAULT_HOST;
-int        g_webPort              = DEFAULT_WEB_PORT;
-CStdString g_username             = "";
-CStdString g_password             = "";
-bool       g_useFavourites        = false;
-bool       g_useFavouritesFile    = false;
-CStdString g_favouritesFile       = "";
-int        g_groupRecordings      = DvbRecording::GROUPING_DISABLED;
-bool       g_useTimeshift         = false;
-CStdString g_timeshiftBufferPath  = DEFAULT_TSBUFFERPATH;
-bool       g_useRTSP              = false;
-int        g_prependOutline       = PrependOutline::IN_EPG;
-bool       g_lowPerformance       = false;
+CStdString     g_hostname             = DEFAULT_HOST;
+int            g_webPort              = DEFAULT_WEB_PORT;
+CStdString     g_username             = "";
+CStdString     g_password             = "";
+bool           g_useFavourites        = false;
+bool           g_useFavouritesFile    = false;
+CStdString     g_favouritesFile       = "";
+DvbRecording::Grouping g_groupRecordings = DvbRecording::Grouping::DISABLED;
+bool           g_useTimeshift         = false;
+CStdString     g_timeshiftBufferPath  = DEFAULT_TSBUFFERPATH;
+bool           g_useRTSP              = false;
+PrependOutline g_prependOutline       = PrependOutline::IN_EPG;
+bool           g_lowPerformance       = false;
 
 ADDON_STATUS m_curStatus    = ADDON_STATUS_UNKNOWN;
 CHelper_libXBMC_addon *XBMC = NULL;
@@ -82,7 +82,7 @@ void ADDON_ReadSettings(void)
     g_favouritesFile = buffer;
 
   if (!XBMC->GetSetting("grouprecordings", &g_groupRecordings))
-    g_groupRecordings = DvbRecording::GROUPING_DISABLED;
+    g_groupRecordings = DvbRecording::Grouping::DISABLED;
 
   if (!XBMC->GetSetting("usetimeshift", &g_useTimeshift))
     g_useTimeshift = false;
@@ -111,7 +111,7 @@ void ADDON_ReadSettings(void)
   XBMC->Log(LOG_DEBUG, "Use favourites: %s", (g_useFavourites) ? "yes" : "no");
   if (g_useFavouritesFile)
     XBMC->Log(LOG_DEBUG, "Favourites file: %s", g_favouritesFile.c_str());
-  if (g_groupRecordings != DvbRecording::GROUPING_DISABLED)
+  if (g_groupRecordings != DvbRecording::Grouping::DISABLED)
     XBMC->Log(LOG_DEBUG, "Group recordings: %d", g_groupRecordings);
   XBMC->Log(LOG_DEBUG, "Timeshift: %s", (g_useTimeshift) ? "enabled" : "disabled");
   if (g_useTimeshift)
@@ -261,7 +261,7 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
   }
   else if (sname == "prependoutline")
   {
-    PrependOutline::options newValue = *(const PrependOutline::options *)settingValue;
+    PrependOutline newValue = *(const PrependOutline *)settingValue;
     if (g_prependOutline != newValue)
     {
       g_prependOutline = newValue;
@@ -338,14 +338,14 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
 
 const char *GetBackendName(void)
 {
-  static const CStdString name = DvbData ? DvbData->GetBackendName()
+  static const CStdString& name = DvbData ? DvbData->GetBackendName()
     : "unknown";
   return name.c_str();
 }
 
 const char *GetBackendVersion(void)
 {
-  static const CStdString version = DvbData ? DvbData->GetBackendVersion()
+  static const CStdString& version = DvbData ? DvbData->GetBackendVersion()
     : "UNKNOWN";
   return version.c_str();
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -338,14 +338,14 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
 
 const char *GetBackendName(void)
 {
-  static const CStdString& name = DvbData ? DvbData->GetBackendName()
+  static const CStdString &name = DvbData ? DvbData->GetBackendName()
     : "unknown";
   return name.c_str();
 }
 
 const char *GetBackendVersion(void)
 {
-  static const CStdString& version = DvbData ? DvbData->GetBackendVersion()
+  static const CStdString &version = DvbData ? DvbData->GetBackendVersion()
     : "UNKNOWN";
   return version.c_str();
 }
@@ -438,7 +438,8 @@ PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool radio)
     ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
 }
 
-PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group)
+PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle,
+    const PVR_CHANNEL_GROUP &group)
 {
   return (DvbData && DvbData->IsConnected()
       && DvbData->GetChannelGroupMembers(handle, group))

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -299,14 +299,12 @@ void ADDON_Announce(const char *_UNUSED(flag), const char *sender,
 
 const char* GetPVRAPIVersion(void)
 {
-  static const char *apiVersion = XBMC_PVR_API_VERSION;
-  return apiVersion;
+  return XBMC_PVR_API_VERSION;
 }
 
 const char* GetMininumPVRAPIVersion(void)
 {
-  static const char *minApiVersion = XBMC_PVR_MIN_API_VERSION;
-  return minApiVersion;
+  return XBMC_PVR_MIN_API_VERSION;
 }
 
 const char* GetGUIAPIVersion(void)

--- a/src/client.h
+++ b/src/client.h
@@ -22,6 +22,7 @@
 #ifndef PVR_DVBVIEWER_CLIENT_H
 #define PVR_DVBVIEWER_CLIENT_H
 
+#include "DvbData.h"
 #include "kodi/libXBMC_addon.h"
 #include "kodi/libXBMC_pvr.h"
 #include "p8-platform/util/StdString.h"
@@ -60,32 +61,30 @@
 #define DEFAULT_WEB_PORT         8089
 #define DEFAULT_TSBUFFERPATH     "special://userdata/addon_data/pvr.dvbviewer"
 
-extern CStdString    g_hostname;
-extern int           g_webPort;
-extern CStdString    g_username;
-extern CStdString    g_password;
-extern bool          g_useFavourites;
-extern bool          g_useFavouritesFile;
-extern CStdString    g_favouritesFile;
-extern int           g_groupRecordings;
-extern bool          g_useTimeshift;
-extern CStdString    g_timeshiftBufferPath;
-extern bool          g_useRTSP;
-extern int           g_prependOutline;
-extern bool          g_lowPerformance;
+enum class PrependOutline
+  : int // same type as addon settings
+{
+  NEVER = 0,
+  IN_EPG,
+  IN_RECORDINGS,
+  ALWAYS
+};
+
+extern CStdString     g_hostname;
+extern int            g_webPort;
+extern CStdString     g_username;
+extern CStdString     g_password;
+extern bool           g_useFavourites;
+extern bool           g_useFavouritesFile;
+extern CStdString     g_favouritesFile;
+extern DvbRecording::Grouping g_groupRecordings;
+extern bool           g_useTimeshift;
+extern CStdString     g_timeshiftBufferPath;
+extern bool           g_useRTSP;
+extern PrependOutline g_prependOutline;
+extern bool           g_lowPerformance;
 
 extern ADDON::CHelper_libXBMC_addon *XBMC;
 extern CHelper_libXBMC_pvr *PVR;
-
-//TODO: convert to enum class as soon as c++11 is available
-class PrependOutline
-{
-public:
-  enum options { NEVER = 0, IN_EPG, IN_RECORDINGS, ALWAYS };
-  static bool test(options flag)
-  {
-    return (g_prependOutline == flag || g_prependOutline == ALWAYS);
-  }
-};
 
 #endif

--- a/symbols.exp
+++ b/symbols.exp
@@ -1,0 +1,2 @@
+get_addon
+ADDON_*


### PR DESCRIPTION
This is a minimal implementation for PVR API 5.1.0 (+ some older commits I had lying around)

There's still a lot to do but this should at least get the PVR working again

For yet unknown reason Kodi doesn't call `CloseLiveStream` + `OpenLiveStream` on channel switching anymore. So the PVR is doing this now.

Another issue is the video players current time is jumping back and forth as soon as I'm returning `false` on `IsRealTimeStream`. Although there is at least 10MB of data (I'm not doing any demuxing) in the local timeshift buffer available. So for now I'm just returning `true` here.