### PR TITLE
Rename addon title to "DVBViewer PVR Client Addon"

### DIFF
--- a/pvr.dvbviewer/addon.xml.in
+++ b/pvr.dvbviewer/addon.xml.in
@@ -2,7 +2,7 @@
 <addon
   id="pvr.dvbviewer"
   version="2.2.0"
-  name="DVBViewer Client"
+  name="DVBViewer PVR Client Addon"
   provider-name="A600, Manuel Mausz">
   <requires>
     <c-pluff version="0.1"/>


### PR DESCRIPTION
Suggest renaming of addon title to "DVBViewer PVR Client Addon"just to try to make it a little more clear and more consistant with the naming standard of the other PVR client addons for Kodi.