### PR TITLE
Store/read recording watched state (play position) on the backend (DMS 2.1.2 or higher required)

### DIFF
--- a/pvr.dvbviewer/addon.xml.in
+++ b/pvr.dvbviewer/addon.xml.in
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvbviewer"
-  version="3.6.7"
+  version="3.6.8"
   name="DVBViewer Client"
-  provider-name="Manuel Mausz">
+  provider-name="Manuel Mausz & pOpY">
   <requires>@ADDON_DEPENDS@</requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.dvbviewer/changelog.txt
+++ b/pvr.dvbviewer/changelog.txt
@@ -1,3 +1,6 @@
+3.6.8
+[added] Store/resume recording watched state on the backend (DMS 2.1.2 or higher required)
+
 3.6.7
 [added] AutoTimers: Populate the series-field with the timers name
 [added] PVR API 5.10.0: Add stream read chunk size as addon setting

--- a/src/DvbData.h
+++ b/src/DvbData.h
@@ -31,6 +31,8 @@
 #define DAY_SECS                     (24 * 60 * 60)
 #define DELPHI_DATE                  (25569)
 
+#define DMS_GUID_KVSTORE            "b3c542c3-34fa-482f-919e-251a3f4cb23b"
+
 namespace dvbviewer
 {
   std::string URLEncode(const std::string& data);
@@ -160,6 +162,8 @@ public:
   RecordingReader *OpenRecordedStream(const PVR_RECORDING &recinfo);
   bool GetRecordingEdl(const PVR_RECORDING &recinfo, PVR_EDL_ENTRY edl[],
       int *size);
+  bool SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition);
+  int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording);
 
   bool OpenLiveStream(const PVR_CHANNEL &channelinfo);
   void CloseLiveStream();

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -104,6 +104,8 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
  ***********************************************************/
 PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
 {
+  unsigned int iver = 0;
+  if (DvbData && DvbData->IsConnected()) iver = DvbData->GetBackendVersion();
   pCapabilities->bSupportsEPG                = true;
   pCapabilities->bSupportsTV                 = true;
   pCapabilities->bSupportsRadio              = true;
@@ -116,7 +118,7 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
   pCapabilities->bHandlesInputStream         = true;
   pCapabilities->bHandlesDemuxing            = false;
   pCapabilities->bSupportsRecordingPlayCount = false;
-  pCapabilities->bSupportsLastPlayedPosition = false;
+  pCapabilities->bSupportsLastPlayedPosition = (iver >= DMS_VERSION_NUM(2, 1, 2, 0) ? true : false);
   pCapabilities->bSupportsRecordingEdl       = true;
   pCapabilities->bSupportsRecordingsRename   = false;
   pCapabilities->bSupportsRecordingsLifetimeChange = false;
@@ -472,6 +474,24 @@ PVR_ERROR GetRecordingEdl(const PVR_RECORDING &recording, PVR_EDL_ENTRY edl[],
     ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
 }
 
+PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition)
+{
+  return (DvbData && DvbData->IsConnected()
+    && DvbData->SetRecordingLastPlayedPosition(recording, lastplayedposition))
+    ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
+}
+
+int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording)
+{
+  if (!DvbData)
+    return PVR_ERROR_SERVER_ERROR;
+
+  if (DvbData->IsConnected() == false)
+    return PVR_ERROR_SERVER_ERROR;
+
+  return DvbData->GetRecordingLastPlayedPosition(recording);
+}
+
 /** UNUSED API FUNCTIONS */
 void OnSystemSleep(void) {}
 void OnSystemWake(void) {}
@@ -491,9 +511,7 @@ void DemuxReset(void) {}
 void DemuxFlush(void) {}
 PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING&, int) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING&, int) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }
-int GetRecordingLastPlayedPosition(const PVR_RECORDING&) { return -1; }
 PVR_ERROR RenameRecording(const PVR_RECORDING&) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR UndeleteRecording(const PVR_RECORDING&) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteAllRecordingsFromTrash() { return PVR_ERROR_NOT_IMPLEMENTED; }


### PR DESCRIPTION
This PR adds the feature that is stores/reads the recording last played position to/from the DMS backend.
So the recording watched states gets synced on all clients.
DMS 2.1.2 or higher required!

Please review and merge.