### PR TITLE
Fix string nullptr assignment to ConnectionStateChange

### DIFF
--- a/pvr.dvbviewer/addon.xml.in
+++ b/pvr.dvbviewer/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvbviewer"
-  version="6.0.0"
+  version="6.0.1"
   name="DVBViewer Client"
   provider-name="Manuel Mausz">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.dvbviewer/changelog.txt
+++ b/pvr.dvbviewer/changelog.txt
@@ -1,3 +1,6 @@
+6.0.1:
+[fixed] string nullptr assignment to ConnectionStateChange
+
 6.0.0:
 [updated] PVR API 7.0.0
 [updated] Rework addon to support new API interface

--- a/src/DvbData.cpp
+++ b/src/DvbData.cpp
@@ -1714,10 +1714,9 @@ void Dvb::SetConnectionState(PVR_CONNECTION_STATE state,
       va_list argList;
       va_start(argList, message);
       tmp = StringUtils::FormatV(message, argList);
-      message = tmp.c_str();
       va_end(argList);
     }
-    ConnectionStateChange(m_settings.m_hostname, m_state, message);
+    ConnectionStateChange(m_settings.m_hostname, m_state, tmp);
   }
 }
 


### PR DESCRIPTION
6.0.1:
[fixed] string nullptr assignment to ConnectionStateChange
