### PR TITLE
read user and pass settings as string and not integer

### DIFF
--- a/pvr.dvbviewer/addon.xml.in
+++ b/pvr.dvbviewer/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvbviewer"
-  version="6.0.1"
+  version="6.0.2"
   name="DVBViewer Client"
   provider-name="Manuel Mausz">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.dvbviewer/changelog.txt
+++ b/pvr.dvbviewer/changelog.txt
@@ -1,3 +1,6 @@
+6.0.2:
+[fixed] read user and pass settings as string and not integer
+
 6.0.1:
 [fixed] string nullptr assignment to ConnectionStateChange
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -33,8 +33,8 @@ void Settings::ReadFromKodi()
   if (!kodi::CheckSettingInt("webport", m_webPort))
     m_webPort = DEFAULT_WEB_PORT;
 
-  m_username = kodi::GetSettingInt("user");
-  m_password = kodi::GetSettingInt("pass");
+  m_username = kodi::GetSettingString("user");
+  m_password = kodi::GetSettingString("pass");
   m_profileId = kodi::GetSettingInt("profileid");
   m_useWoL = kodi::GetSettingBoolean("usewol");
   m_mac = kodi::GetSettingString("mac");


### PR DESCRIPTION
6.0.2:
- [fixed] read user and pass settings as string and not integer