### PR TITLE
Remove p8platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,26 +14,46 @@ env:
 matrix:
   include:
     - os: linux
-      dist: xenial
+      dist: bionic
       sudo: required
       compiler: gcc
     - os: linux
-      dist: xenial
+      dist: bionic
       sudo: required
       compiler: clang
+    - os: linux
+      dist: bionic
+      sudo: required
+      compiler: gcc
+      env: DEBIAN_BUILD=true
+    - os: linux
+      dist: focal
+      sudo: required
+      compiler: gcc
+      env: DEBIAN_BUILD=true
     - os: osx
       osx_image: xcode10.2
+
+before_install:
+  - if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/xbmc-nightly; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get update; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get install fakeroot; fi
 
 #
 # The addon source is automatically checked out in $TRAVIS_BUILD_DIR,
 # we'll put the Kodi source on the same level
 #
 before_script:
-  - cd $TRAVIS_BUILD_DIR/..
-  - git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git
-  - cd ${app_id} && mkdir build && cd build
-  - mkdir -p definition/${app_id}
-  - echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt
-  - cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons
+  - if [[ $DEBIAN_BUILD != true ]]; then cd $TRAVIS_BUILD_DIR/..; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then cd ${app_id} && mkdir build && cd build; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then mkdir -p definition/${app_id}; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep $TRAVIS_BUILD_DIR; fi
 
-script: make
+script: 
+  - if [[ $DEBIAN_BUILD != true ]]; then make; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then ./debian-addon-package-test.sh $TRAVIS_BUILD_DIR; fi
+  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,8 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 
 find_package(TinyXML REQUIRED)
 find_package(Kodi REQUIRED)
-find_package(p8-platform REQUIRED)
 
-include_directories(${p8-platform_INCLUDE_DIRS}
-                    ${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
+include_directories(${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
                     ${TINYXML_INCLUDE_DIRS})
 
 add_definitions(-D__STDC_FORMAT_MACROS)
@@ -33,8 +31,7 @@ set(DVBVIEWER_HEADERS src/client.h
                       src/TimeshiftBuffer.h
                       src/utilities/XMLUtils.h)
 
-set(DEPLIBS ${p8-platform_LIBRARIES}
-            ${TINYXML_LIBRARIES})
+set(DEPLIBS ${TINYXML_LIBRARIES})
 
 # check if the linker supports version script or symbols list
 if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,6 @@ environment:
       PLATFORM: linux-x86_64
     - APPVEYOR_BUILD_WORKER_IMAGE: ubuntu
       PLATFORM: linux-clang-x86_64
-    - APPVEYOR_BUILD_WORKER_IMAGE: ubuntu
-      PLATFORM: rbpi-arm
 
 init:
   - ps: |
@@ -37,11 +35,6 @@ install:
           sudo apt-get install --yes --no-install-recommends --no-upgrade clang
           export CC=clang CXX=clang++
           ;;
-        "rbpi-arm")
-          git clone -q --depth=1 https://github.com/raspberrypi/tools.git $ROOT/tools
-          # we don't need the firmware. fake it
-          mkdir -p $ROOT/firmware/opt/vc/include
-          ;;
       esac
 
 before_build:
@@ -56,17 +49,6 @@ before_build:
 
       # generate toolchain file
       params=()
-      case "$PLATFORM" in
-        "rbpi-arm")
-          params+=(
-            --with-platform=raspberry-pi2
-            --host=arm-linux-gnueabihf
-            --with-toolchain="$ROOT/tools/arm-bcm2708/arm-linux-gnueabihf"
-            --with-firmware="$ROOT/firmware"
-            --build=x86_64-linux
-          )
-          ;;
-      esac
 
       cd "$KODI/tools/depends"
       sed -i 's/@platform_ldflags@//' target/Toolchain_binaddons.cmake.in

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: kodi-pvr-dvbviewer
 Priority: extra
 Maintainer: Manuel Mausz <manuel-kodi@mausz.at>
-Build-Depends: debhelper (>= 9.0.0), cmake,
+Build-Depends: debhelper (>= 9.0.0), cmake, libtinyxml-dev,
                kodi-addon-dev
 Standards-Version: 4.1.2
 Section: libs

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-dvbviewer
 Priority: extra
 Maintainer: Manuel Mausz <manuel-kodi@mausz.at>
 Build-Depends: debhelper (>= 9.0.0), cmake,
-               libp8-platform-dev, kodi-addon-dev
+               kodi-addon-dev
 Standards-Version: 4.1.2
 Section: libs
 

--- a/depends/common/kodi-platform/deps.txt
+++ b/depends/common/kodi-platform/deps.txt
@@ -1,2 +1,0 @@
-tinyxml
-p8-platform

--- a/depends/common/kodi-platform/kodi-platform.txt
+++ b/depends/common/kodi-platform/kodi-platform.txt
@@ -1,1 +1,0 @@
-kodi-platform https://github.com/xbmc/kodi-platform 809c5e9d711e378561440a896fcb7dbcd009eb3d

--- a/depends/common/p8-platform/p8-platform.txt
+++ b/depends/common/p8-platform/p8-platform.txt
@@ -1,1 +1,0 @@
-p8-platform https://github.com/xbmc/platform.git cee64e9dc0b69e8d286dc170a78effaabfa09c44

--- a/depends/windowsstore/p8-platform/p8-platform.txt
+++ b/depends/windowsstore/p8-platform/p8-platform.txt
@@ -1,1 +1,0 @@
-p8-platform https://github.com/afedchin/platform.git win10

--- a/pvr.dvbviewer/addon.xml.in
+++ b/pvr.dvbviewer/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvbviewer"
-  version="6.0.6"
+  version="6.0.7"
   name="DVBViewer Client"
   provider-name="Manuel Mausz">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.dvbviewer/changelog.txt
+++ b/pvr.dvbviewer/changelog.txt
@@ -1,3 +1,14 @@
+6.0.7:
+[removed] Remove dependency on p8-platform and kodi-platform
+[updated] Update to use std::thread
+[updated] Update to use std::mutex and locks
+[updated] Replace SAFE_DELETE macro with SafeDelete template
+[updated] Use kodi StringUtils and update system headers
+[removed] Remove rpi platform as it's now removed from matrix
+[updated] Include windows.h for Windows for GetUTCOffset()
+[updated] While sleeping for long periods allow break on destruction
+[updated] Update travis.yml for cpp17 and debian
+
 6.0.6:
 [removed] External kodiplatform dependency
 [added] libp8-platform-dev dependency

--- a/src/DvbData.cpp
+++ b/src/DvbData.cpp
@@ -15,7 +15,6 @@
 #include <kodi/General.h>
 #include <kodi/Network.h>
 #include <kodi/tools/StringUtils.h>
-#include "p8-platform/util/util.h"
 
 #include <tinyxml.h>
 #include <inttypes.h>
@@ -30,6 +29,15 @@ using namespace dvbviewer;
 using namespace dvbviewer::utilities;
 using namespace kodi::tools;
 using namespace P8PLATFORM;
+
+template<typename T> void SafeDelete(T*& p)
+{
+  if (p)
+  {
+    delete p;
+    p = nullptr;
+  }
+}
 
 /* Copied from xbmc/URL.cpp */
 std::string dvbviewer::URLEncode(const std::string& data)
@@ -794,7 +802,7 @@ bool Dvb::OpenRecordedStream(const kodi::addon::PVRRecording& recinfo)
   CLockObject lock(m_mutex);
 
   if (m_recReader)
-    SAFE_DELETE(m_recReader);
+    SafeDelete(m_recReader);
 
   std::string url;
   switch(m_settings.m_recordingTranscoding)
@@ -837,7 +845,7 @@ bool Dvb::OpenRecordedStream(const kodi::addon::PVRRecording& recinfo)
 void Dvb::CloseRecordedStream()
 {
   if (m_recReader)
-    SAFE_DELETE(m_recReader);
+    SafeDelete(m_recReader);
 }
 
 int Dvb::ReadRecordedStream(unsigned char* buffer, unsigned int size)
@@ -999,7 +1007,7 @@ void Dvb::CloseLiveStream()
 {
   CLockObject lock(m_mutex);
   m_currentChannel = 0;
-  SAFE_DELETE(m_strReader);
+  SafeDelete(m_strReader);
 }
 
 bool Dvb::IsRealTimeStream()

--- a/src/DvbData.cpp
+++ b/src/DvbData.cpp
@@ -25,6 +25,10 @@
 #include <memory>
 #include <ctime>
 
+#if defined(TARGET_WINDOWS)
+#include <windows.h>
+#endif
+
 using namespace dvbviewer;
 using namespace dvbviewer::utilities;
 using namespace kodi::tools;

--- a/src/DvbData.cpp
+++ b/src/DvbData.cpp
@@ -12,9 +12,9 @@
 #include "client.h"
 #include "utilities/XMLUtils.h"
 
-#include "kodi/General.h"
-#include "kodi/Network.h"
-#include "p8-platform/util/StringUtils.h"
+#include <kodi/General.h>
+#include <kodi/Network.h>
+#include <kodi/tools/StringUtils.h>
 #include "p8-platform/util/util.h"
 
 #include <tinyxml.h>
@@ -28,6 +28,7 @@
 
 using namespace dvbviewer;
 using namespace dvbviewer::utilities;
+using namespace kodi::tools;
 using namespace P8PLATFORM;
 
 /* Copied from xbmc/URL.cpp */
@@ -44,7 +45,7 @@ std::string dvbviewer::URLEncode(const std::string& data)
 
     // Don't URL encode "-_.!()" according to RFC1738
     // TODO: Update it to "-_.~" after Gotham according to RFC3986
-    if (StringUtils::isasciialphanum(kar) || kar == '-' || kar == '.'
+    if (StringUtils::IsAsciiAlphaNum(kar) || kar == '-' || kar == '.'
         || kar == '_' || kar == '!' || kar == '(' || kar == ')')
       result.push_back(kar);
     else

--- a/src/DvbData.h
+++ b/src/DvbData.h
@@ -14,7 +14,7 @@
 #include "Settings.h"
 #include "Timers.h"
 
-#include "kodi/addon-instance/PVR.h"
+#include <kodi/addon-instance/PVR.h>
 #include "p8-platform/threads/threads.h"
 
 #include <list>

--- a/src/DvbData.h
+++ b/src/DvbData.h
@@ -253,6 +253,7 @@ private:
   std::string BuildURL(const char* path, ...);
   const std::string GetLiveStreamURL(
       const kodi::addon::PVRChannel& channelinfo);
+  void SleepMs(uint32_t ms);
 
 private:
   std::atomic<PVR_CONNECTION_STATE> m_state = { PVR_CONNECTION_STATE_UNKNOWN };

--- a/src/DvbData.h
+++ b/src/DvbData.h
@@ -20,6 +20,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <functional>
 #include <atomic>
 
@@ -284,7 +285,7 @@ private:
   KVStore m_kvstore;
   Settings m_settings;
 
-  P8PLATFORM::CMutex m_mutex;
+  std::mutex m_mutex;
 };
 
 } // namespace dvbviewer

--- a/src/DvbData.h
+++ b/src/DvbData.h
@@ -15,14 +15,14 @@
 #include "Timers.h"
 
 #include <kodi/addon-instance/PVR.h>
-#include "p8-platform/threads/threads.h"
 
+#include <atomic>
+#include <functional>
 #include <list>
 #include <map>
 #include <memory>
 #include <mutex>
-#include <functional>
-#include <atomic>
+#include <thread>
 
 // minimum version required
 #define DMS_MIN_VERSION 1, 33, 2, 0
@@ -138,7 +138,7 @@ typedef std::vector<DvbChannel *> DvbChannels_t;
 typedef std::vector<DvbGroup> DvbGroups_t;
 
 class Dvb
-  : public kodi::addon::CInstancePVRClient, public P8PLATFORM::CThread
+  : public kodi::addon::CInstancePVRClient
 {
 public:
   Dvb(KODI_HANDLE instance, const std::string& kodiVersion,
@@ -238,7 +238,7 @@ public:
   std::unique_ptr<httpResponse> GetFromAPI(const char* format, ...);
 
 protected:
-  virtual void *Process(void) override;
+  void Process();
 
 private:
   // functions
@@ -285,6 +285,8 @@ private:
   KVStore m_kvstore;
   Settings m_settings;
 
+  std::atomic<bool> m_running = {false};
+  std::thread m_thread;
   std::mutex m_mutex;
 };
 

--- a/src/IStreamReader.h
+++ b/src/IStreamReader.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "kodi/Filesystem.h"
+#include <kodi/Filesystem.h>
 
 #include <ctime>
 

--- a/src/KVStore.cpp
+++ b/src/KVStore.cpp
@@ -10,7 +10,7 @@
 #include "client.h"
 #include "DvbData.h"
 
-#include "p8-platform/util/StringUtils.h"
+#include <kodi/tools/StringUtils.h>
 
 #define CACHE_TTL 60
 
@@ -35,7 +35,7 @@ void KVStore::Reset()
   /* UUID like section name for our keys. Prefixed for better readability.
    * Suffixed by our PVR instance/profile.
    */
-  m_section = StringUtils::Format("kodi-bfa5-4ac6-8bc2-profile%02x",
+  m_section = kodi::tools::StringUtils::Format("kodi-bfa5-4ac6-8bc2-profile%02x",
     m_cli.GetSettings().m_profileId);
 }
 

--- a/src/RecordingReader.cpp
+++ b/src/RecordingReader.cpp
@@ -9,8 +9,6 @@
 #include "RecordingReader.h"
 #include "client.h"
 
-#include "p8-platform/threads/mutex.h"
-
 #include <algorithm>
 #include <ctime>
 

--- a/src/RecordingReader.h
+++ b/src/RecordingReader.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "kodi/Filesystem.h"
+#include <kodi/Filesystem.h>
 
 #include <atomic>
 #include <chrono>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -10,12 +10,13 @@
 #include "client.h"
 #include "DvbData.h"
 
-#include "kodi/Filesystem.h"
-#include "kodi/General.h"
-#include "p8-platform/util/StringUtils.h"
-#include "tinyxml.h"
+#include <kodi/Filesystem.h>
+#include <kodi/General.h>
+#include <kodi/tools/StringUtils.h>
+#include <tinyxml.h>
 
 using namespace dvbviewer;
+using namespace kodi::tools;
 
 Settings::Settings()
 {

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "kodi/AddonBase.h"
+#include <kodi/AddonBase.h>
 
 #include <string>
 

--- a/src/Timers.cpp
+++ b/src/Timers.cpp
@@ -14,12 +14,13 @@
 #include <algorithm>
 #include <ctime>
 
-#include "inttypes.h"
-#include "kodi/General.h"
-#include "p8-platform/util/StringUtils.h"
+#include <inttypes.h>
+#include <kodi/General.h>
+#include <kodi/tools/StringUtils.h>
 
 using namespace dvbviewer;
 using namespace dvbviewer::utilities;
+using namespace kodi::tools;
 
 #define TIMER_UPDATE_MEMBER(member) \
   if (member != other.member) \

--- a/src/Timers.h
+++ b/src/Timers.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "kodi/addon-instance/pvr/Timers.h"
-#include "tinyxml.h"
+#include <kodi/addon-instance/pvr/Timers.h>
+#include <tinyxml.h>
 
 #include <string>
 #include <map>

--- a/src/TimeshiftBuffer.cpp
+++ b/src/TimeshiftBuffer.cpp
@@ -11,8 +11,6 @@
 #include "StreamReader.h"
 #include "client.h"
 
-#include "p8-platform/util/util.h"
-
 #define BUFFER_SIZE 32 * 1024
 #define DEFAULT_READ_TIMEOUT 10
 #define READ_WAITTIME 50
@@ -48,7 +46,7 @@ TimeshiftBuffer::~TimeshiftBuffer(void)
   }
   if (m_filebufferReadHandle.IsOpen())
     m_filebufferReadHandle.Close();
-  SAFE_DELETE(m_strReader);
+  delete m_strReader;
   kodi::Log(ADDON_LOG_DEBUG, "Timeshift: Stopped");
 }
 

--- a/src/TimeshiftBuffer.h
+++ b/src/TimeshiftBuffer.h
@@ -9,7 +9,8 @@
 #pragma once
 
 #include "IStreamReader.h"
-#include "kodi/Filesystem.h"
+
+#include <kodi/Filesystem.h>
 
 #include <atomic>
 #include <condition_variable>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -14,7 +14,7 @@ ADDON_STATUS CDVBViewerAddon::CreateInstance(int instanceType,
     const std::string& instanceID, KODI_HANDLE instance,
     const std::string& version, KODI_HANDLE& addonInstance)
 {
-  P8PLATFORM::CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   if (instanceType == ADDON_INSTANCE_PVR)
   {
@@ -34,7 +34,7 @@ ADDON_STATUS CDVBViewerAddon::CreateInstance(int instanceType,
 void CDVBViewerAddon::DestroyInstance(int instanceType,
     const std::string& instanceID, KODI_HANDLE addonInstance)
 {
-  P8PLATFORM::CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   kodi::Log(ADDON_LOG_DEBUG, "%s: Destroying DVBViewer PVR-Client", __FUNCTION__);
 
@@ -45,7 +45,7 @@ void CDVBViewerAddon::DestroyInstance(int instanceType,
 ADDON_STATUS CDVBViewerAddon::SetSetting(const std::string& settingName,
     const kodi::CSettingValue& settingValue)
 {
-  P8PLATFORM::CLockObject lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   // SetSetting can occur when the addon is enabled, but TV support still
   // disabled. In that case the addon is not loaded, so we should not try

--- a/src/client.h
+++ b/src/client.h
@@ -10,7 +10,7 @@
 
 #include "DvbData.h"
 
-#include "p8-platform/threads/threads.h"
+#include <mutex>
 
 #include <kodi/AddonBase.h>
 
@@ -31,5 +31,5 @@ public:
 
 private:
   dvbviewer::Dvb* m_dvbData = nullptr;
-  P8PLATFORM::CMutex m_mutex;
+  std::mutex m_mutex;
 };


### PR DESCRIPTION
6.0.7:
- [removed] Remove dependency on p8-platform and kodi-platform
- [updated] Update to use std::thread
- [updated] Update to use std::mutex and locks
- [updated] Replace SAFE_DELETE macro with SafeDelete template
- [updated] Use kodi StringUtils and update system headers
- [removed] Remove rpi platform as it's now removed from matrix
- [updated] Include windows.h for Windows for GetUTCOffset()
- [updated] While sleeping for long periods allow break on destruction
- [updated] Update travis.yml for cpp17 and debian


This could use a runtime test of possible @manuelm. When you have time, no rush.