### PR TITLE
Fix duplicate asset tag in addon.xml

### DIFF
--- a/pvr.dvbviewer/addon.xml.in
+++ b/pvr.dvbviewer/addon.xml.in
@@ -185,6 +185,5 @@
     <assets>
       <icon>icon.png</icon>
     </assets>
-    </assets>
   </extension>
 </addon>


### PR DESCRIPTION
Fix duplicate </asset> tag in addon.xml.in introduced in https://github.com/kodi-pvr/pvr.dvbviewer/commit/fa201b47d3a5d21cbfcb3256a299d9c72e72bf82