### PR TITLE
[Nexus] Increase version to 20.4.0

### DIFF
--- a/pvr.dvbviewer/addon.xml.in
+++ b/pvr.dvbviewer/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvbviewer"
-  version="20.3.0"
+  version="20.4.0"
   name="DVBViewer Client"
   provider-name="Manuel Mausz">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.dvbviewer/changelog.txt
+++ b/pvr.dvbviewer/changelog.txt
@@ -1,3 +1,6 @@
+v20.4.0
+- Kodi inputstream API update to version 3.2.0
+
 v20.3.0
 - Require DMS 3.0.0 or higher
 - Make sure to only reference non-hidden channels


### PR DESCRIPTION
Bump version for inpustream API change
due to:
https://github.com/xbmc/xbmc/pull/21390
https://github.com/xbmc/xbmc/pull/21319
